### PR TITLE
Support non-serial device via dependency injection

### DIFF
--- a/generic_scpi_driver/__init__.py
+++ b/generic_scpi_driver/__init__.py
@@ -7,4 +7,4 @@ from .generic_aqctl import get_controller_func
 
 __author__ = "Charles Baynham <charles.baynham@npl.co.uk>"
 __all__ = ["GenericDriver", "with_handler", "with_lock", "get_controller_func"]
-__version__ = "1.4.2"
+__version__ = "1.5"

--- a/generic_scpi_driver/driver.py
+++ b/generic_scpi_driver/driver.py
@@ -10,70 +10,18 @@ import re
 import time
 from collections import namedtuple
 from functools import partial
+from .session import Session
 from functools import wraps
 from threading import RLock
 from types import FunctionType
-
 import pyvisa
-from serial.tools.list_ports import grep as grep_serial_ports
 
 logger = logging.getLogger("GenericSCPI")
 
-# from typing import Callable, List, Tuple
+from typing import Callable, Optional
 
 _locks = {}
 _sessions = {}
-
-
-def get_hwid_from_com_port(com_port):
-    """Get a uniquely identifying HWID from a device attached to a COM port
-
-    The HWID of a device is (/ should be) a unique string that identifies it. Unlike the COM port,
-    this string is intrinsic to the device and will never change. Referring to devices by these
-    strings is therefore a robust way of doing things.
-
-    Args:
-        com_port (str): COM port e.g. "COM11"
-
-    Raises:
-        RuntimeError: Raised if the device is not found or multiple matches are found
-
-    Returns:
-        str: HWID of the device on the given COM port
-    """
-    matches = list(grep_serial_ports(com_port))
-    if not matches:
-        raise RuntimeError("Device {} not found".format(com_port))
-    if len(matches) > 1:
-        raise RuntimeError("Multiple matched for device {}".format(com_port))
-    return matches[0].hwid
-
-
-def get_com_port_by_hwid(hwid):
-    """Get the current COM port based on a uniquely identifying hardware ID of a device
-
-    The HWID of a device is (/ should be) a unique string that identifies it. Unlike the COM port,
-    this string is intrinsic to the device and will never change. Referring to devices by these
-    strings is therefore a robust way of doing things.
-
-    Args:
-        hwid (str): Hardware ID string to match, e.g. 'USB VID:PID=0403:6001 SER=A6003SX4A'.
-                    This is matched using serial.tools.list_ports.grep so can be less specific
-                    if desired. The search should result in a single match otherwise an exception will
-                    be raised.
-
-    Raises:
-        RuntimeError: Raised if the device is not found or multiple matches are found
-
-    Returns:
-        str: current port of the device (e.g. "COM11")
-    """
-    matches = list(grep_serial_ports(hwid))
-    if not matches:
-        raise RuntimeError("Device {} not found".format(hwid))
-    if len(matches) > 1:
-        raise RuntimeError("Multiple matched for device {}".format(hwid))
-    return matches[0].device
 
 
 def with_lock(f):
@@ -97,7 +45,7 @@ def with_lock(f):
 
 def with_handler(f):
     """
-    Decorator to wrap function in a try/except block, handling VISAIOErrors by flush()ing the device,
+    Decorator to wrap function in a try/except block, handling Exceptions by flush()ing the device,
     then passing on the exception.
 
     This decorator expects the instance method self.instr.flush() to exit
@@ -107,7 +55,7 @@ def with_handler(f):
     def wrapped(self, *args, **kw):
         try:
             return f(self, *args, **kw)
-        except pyvisa.VisaIOError:
+        except Exception:
             self._flush_all_buffers()
 
             raise
@@ -135,7 +83,8 @@ class GenericDriver:
     :meth:`GenericDriver._register_query`.
     """
 
-    _simulator_factory = None
+    _session_factory: Callable[..., Session] = None
+    _simulator_factory: Optional[Callable[..., Session]] = None
 
     def __init__(
         self,
@@ -186,19 +135,19 @@ class GenericDriver:
         # Claim this device exclusivly while we manipulate it
         with _locks[self.dev_id]:
             if simulation:
-                if not self.__class__._simulator_factory:
+                if not self._simulator_factory:
                     raise RuntimeError(
                         "Simulation mode is not available: you must first call _register_simulator"
                     )
                 if self.dev_id not in _sessions:
-                    _sessions[self.dev_id] = self.__class__._simulator_factory()
+                    _sessions[self.dev_id] = self._simulator_factory()
             else:
                 if self.dev_id not in _sessions:
-                    # Pass all unrecognised keyword arguments to _setup_device
-                    _sessions[self.dev_id] = self._setup_device(
-                        id, baud_rate=baud_rate, **kwargs
-                    )
-                    self._flush_all_buffers()
+                    # Pass all unrecognised keyword arguments to the session factory
+                    session = self._session_factory(id, baud_rate=baud_rate, **kwargs)
+                    session.flush()
+
+                    _sessions[self.dev_id] = session
 
         self.check_connection()
 
@@ -218,7 +167,7 @@ class GenericDriver:
         del _sessions[self.dev_id]
 
     @property
-    def instr(self):
+    def instr(self) -> Session:
         """
         Get the session for this device.
 
@@ -387,98 +336,11 @@ and expects you to pass it {} arguments named {}.
         """
         pass
 
-    def _flush_all_buffers(self):
-        if not self.simulation:
-            logger.debug("Flushing visa interface with device %s", self.instr)
-            self.instr.flush(
-                pyvisa.constants.VI_READ_BUF_DISCARD
-                | pyvisa.constants.VI_WRITE_BUF_DISCARD
-                | pyvisa.constants.VI_IO_IN_BUF_DISCARD
-                | pyvisa.constants.VI_IO_OUT_BUF_DISCARD
-            )
-
     def ping(self):
         """
         The all-important ping function, without which ARTIQ will brutally kill our controller.
         """
         return True
-
-    @staticmethod
-    def _setup_device(
-        id,
-        baud_rate,
-        read_termination="\n",
-        write_termination="\n",
-        timeout=None,
-        wait_after_connect=0.0,
-    ):
-        """Open a visa connection to the device
-
-        Params:
-            wait_after_connect - Time to wait after opening the connection before flushing it [s]
-
-        Raises:
-            RuntimeError: Raised if VISA comms fail
-
-        :rtype: :class:pyvisa.resources.Resource
-        """
-        id_resolved = get_com_port_by_hwid(id)
-
-        if id_resolved.lower() == id.lower():
-            logger.warning(
-                (
-                    "Initiated device from COM port: it would be more "
-                    'robust to use the HWID instead. For "%s", that\'s "%s"'
-                ),
-                id,
-                id_resolved,
-            )
-
-        logger.debug("Found device %s on COM port %s", id, id_resolved)
-
-        # Get a handle to the instrument
-        rm = pyvisa.ResourceManager("@py")
-
-        logger.debug(f"Devices: {rm.list_resources()}")
-
-        # pyvisa-py doesn't have "COM" aliases for ASRL serial ports, so convert
-        regex_match = re.match(r"^com(\d{1,3})$", id_resolved.lower())
-        if regex_match:
-            id_resolved = f"ASRL{regex_match[1]}"
-
-        logger.debug(f"Connecting to : {id_resolved}")
-
-        instr = rm.open_resource(id_resolved)
-
-        logger.debug(f"Connection: {instr}")
-
-        # Configure the connection as required
-
-        logger.debug(
-            "Setting up connection with baud %s, write_term %s and read_term %s",
-            baud_rate,
-            repr(write_termination),
-            repr(read_termination),
-        )
-
-        instr.baud_rate = baud_rate
-        if read_termination:
-            instr.read_termination = read_termination
-        if write_termination:
-            instr.write_termination = write_termination
-        if timeout:
-            instr.timeout = timeout
-        # instr.data_bits = 8
-        # instr.stop_bits = pyvisa.constants.StopBits.one
-        # instr.parity = pyvisa.constants.Parity.none
-        # instr.flow_control = visa.constants.VI_ASRL_FLOW_NONE
-
-        if wait_after_connect:
-            time.sleep(wait_after_connect)
-
-        logger.debug('Device "{}" init complete'.format(id))
-
-        return instr
 
 
 # _register_query(Driver, "get_identity", "*idn", response_validator=None)

--- a/generic_scpi_driver/driver.py
+++ b/generic_scpi_driver/driver.py
@@ -7,14 +7,14 @@ This module can be used to generate a driver for a device which communicates wit
 import asyncio
 import logging
 import re
-import time
+
 from collections import namedtuple
 from functools import partial
 from .session import Session
 from functools import wraps
 from threading import RLock
 from types import FunctionType
-import pyvisa
+
 
 logger = logging.getLogger("GenericSCPI")
 

--- a/generic_scpi_driver/driver.py
+++ b/generic_scpi_driver/driver.py
@@ -14,6 +14,7 @@ from threading import RLock
 from types import FunctionType
 
 from .session import Session
+from .visa_session import VISASession
 
 
 logger = logging.getLogger("GenericSCPI")
@@ -83,8 +84,8 @@ class GenericDriver:
     :meth:`GenericDriver._register_query`.
     """
 
-    _session_factory: Callable[..., Session] = None
-    _simulator_factory: Optional[Callable[..., Session]] = None
+    session_factory: Callable[..., Session] = None
+    _simulator_factory: Optional[Callable[..., Session]] = VISASession
 
     def __init__(
         self,
@@ -144,7 +145,7 @@ class GenericDriver:
             else:
                 if self.dev_id not in _sessions:
                     # Pass all unrecognised keyword arguments to the session factory
-                    session = self.__class__._session_factory(
+                    session = self.__class__.session_factory(
                         id, baud_rate=baud_rate, **kwargs
                     )
                     session.flush()

--- a/generic_scpi_driver/driver.py
+++ b/generic_scpi_driver/driver.py
@@ -7,13 +7,13 @@ This module can be used to generate a driver for a device which communicates wit
 import asyncio
 import logging
 import re
-
 from collections import namedtuple
 from functools import partial
-from .session import Session
 from functools import wraps
 from threading import RLock
 from types import FunctionType
+
+from .session import Session
 
 
 logger = logging.getLogger("GenericSCPI")
@@ -73,10 +73,10 @@ class GenericDriver:
     Template for devices which communicate by sending / receiving text commands.
     This class should be inherited by your driver.
 
-    You can register new commands by calling :meth:`GenericDriver._register_query`. This will create a
-    method on the class which queries your device returns the response. The
-    class builder supports input and output validation as well as custom error
-    handling.
+    You can register new commands by calling
+    :meth:`GenericDriver._register_query`. This will create a method on the
+    class which queries your device returns the response. The class builder
+    supports input and output validation as well as custom error handling.
 
     If you need more advanced logic in your driver, you can still just add
     methods as normal. They'll work side-by-side with methods registered by

--- a/generic_scpi_driver/driver.py
+++ b/generic_scpi_driver/driver.py
@@ -220,7 +220,7 @@ class GenericDriver:
     @property
     def instr(self):
         """
-        Get the VISA session for this device.
+        Get the session for this device.
 
         This is stored in a shared namespace for this python session,
         so other GenericDrivers can access the same device in a thread-safe way, taking turns via @with_lock.
@@ -278,7 +278,7 @@ class GenericDriver:
         # already present because we will call it from a wrapper
         @with_lock
         @with_handler
-        def func(self, *args):
+        def func(self: GenericDriver, *args):
             arg_strings = []
             for arg, registered_arg in zip(args, registered_args):
                 arg_strings.append(registered_arg.validator(arg))

--- a/generic_scpi_driver/driver.py
+++ b/generic_scpi_driver/driver.py
@@ -33,7 +33,7 @@ def with_lock(f):
     """
 
     @wraps(f)
-    def wrapped(self, *args, **kw):
+    def wrapped(self: "GenericDriver", *args, **kw):
         with _locks[self.dev_id]:
             return f(self, *args, **kw)
 
@@ -52,11 +52,11 @@ def with_handler(f):
     """
 
     @wraps(f)
-    def wrapped(self, *args, **kw):
+    def wrapped(self: "GenericDriver", *args, **kw):
         try:
             return f(self, *args, **kw)
         except Exception:
-            self._flush_all_buffers()
+            self.instr.flush()
 
             raise
 
@@ -238,7 +238,7 @@ class GenericDriver:
 
             logger.debug("Sending command '%s'", cmd_string)
 
-            self._flush_all_buffers()
+            self.instr.flush()
 
             if response_parser:
                 r = self.instr.query(cmd_string)

--- a/generic_scpi_driver/driver.py
+++ b/generic_scpi_driver/driver.py
@@ -135,16 +135,18 @@ class GenericDriver:
         # Claim this device exclusivly while we manipulate it
         with _locks[self.dev_id]:
             if simulation:
-                if not self._simulator_factory:
+                if not self.__class__._simulator_factory:
                     raise RuntimeError(
                         "Simulation mode is not available: you must first call _register_simulator"
                     )
                 if self.dev_id not in _sessions:
-                    _sessions[self.dev_id] = self._simulator_factory()
+                    _sessions[self.dev_id] = self.__class__._simulator_factory()
             else:
                 if self.dev_id not in _sessions:
                     # Pass all unrecognised keyword arguments to the session factory
-                    session = self._session_factory(id, baud_rate=baud_rate, **kwargs)
+                    session = self.__class__._session_factory(
+                        id, baud_rate=baud_rate, **kwargs
+                    )
                     session.flush()
 
                     _sessions[self.dev_id] = session

--- a/generic_scpi_driver/driver.py
+++ b/generic_scpi_driver/driver.py
@@ -84,8 +84,8 @@ class GenericDriver:
     :meth:`GenericDriver._register_query`.
     """
 
-    session_factory: Callable[..., Session] = None
-    _simulator_factory: Optional[Callable[..., Session]] = VISASession
+    session_factory: Callable[..., Session] = VISASession
+    _simulator_factory: Optional[Callable[..., Session]] = None
 
     def __init__(
         self,

--- a/generic_scpi_driver/session.py
+++ b/generic_scpi_driver/session.py
@@ -1,0 +1,40 @@
+class Session:
+    """
+    A Session that encapsulates communication with a device
+
+    Subclasses of Session are passed to :class:`~GenericDriver` and implements
+    the hardware connection to your device. You don't need to define a new type
+    of Session unless your device uses a communication protocol that isn't
+    already implemented by this package.
+    """
+
+    def write(self, s: str) -> None:
+        """
+        Send a string to the device but do not expect a response
+        """
+        raise NotImplementedError
+
+    def query(self, s: str) -> str:
+        """
+        Send a string to the device and expect a string response
+        """
+        raise NotImplementedError
+
+    def flush(self) -> None:
+        """
+        Flush any communication buffers
+
+        This method will be called after initial setup and before all commands.
+        If your Session does not require this functionality, don't implement
+        this function.
+        """
+        pass
+
+    def close(self) -> None:
+        """
+        Terminate communication with the device
+
+        This Session will not be used again after calling close: this method
+        should clean up any resources used, e.g. closing connections.
+        """
+        raise NotImplementedError

--- a/generic_scpi_driver/visa_session.py
+++ b/generic_scpi_driver/visa_session.py
@@ -1,0 +1,175 @@
+from .session import Session
+import logging
+
+import pyvisa
+import re
+import time
+from serial.tools.list_ports import grep as grep_serial_ports
+
+logger = logging.getLogger(__name__)
+
+
+def get_hwid_from_com_port(com_port):
+    """Get a uniquely identifying HWID from a device attached to a COM port
+
+    The HWID of a device is (/ should be) a unique string that identifies it. Unlike the COM port,
+    this string is intrinsic to the device and will never change. Referring to devices by these
+    strings is therefore a robust way of doing things.
+
+    Args:
+        com_port (str): COM port e.g. "COM11"
+
+    Raises:
+        RuntimeError: Raised if the device is not found or multiple matches are found
+
+    Returns:
+        str: HWID of the device on the given COM port
+    """
+    matches = list(grep_serial_ports(com_port))
+    if not matches:
+        raise RuntimeError("Device {} not found".format(com_port))
+    if len(matches) > 1:
+        raise RuntimeError("Multiple matched for device {}".format(com_port))
+    return matches[0].hwid
+
+
+def get_com_port_by_hwid(hwid):
+    """Get the current COM port based on a uniquely identifying hardware ID of a device
+
+    The HWID of a device is (/ should be) a unique string that identifies it. Unlike the COM port,
+    this string is intrinsic to the device and will never change. Referring to devices by these
+    strings is therefore a robust way of doing things.
+
+    Args:
+        hwid (str): Hardware ID string to match, e.g. 'USB VID:PID=0403:6001 SER=A6003SX4A'.
+                    This is matched using serial.tools.list_ports.grep so can be less specific
+                    if desired. The search should result in a single match otherwise an exception will
+                    be raised.
+
+    Raises:
+        RuntimeError: Raised if the device is not found or multiple matches are found
+
+    Returns:
+        str: current port of the device (e.g. "COM11")
+    """
+    matches = list(grep_serial_ports(hwid))
+    if not matches:
+        raise RuntimeError("Device {} not found".format(hwid))
+    if len(matches) > 1:
+        raise RuntimeError("Multiple matched for device {}".format(hwid))
+    return matches[0].device
+
+
+class VISASession(Session):
+    def __init__(
+        self,
+        id,
+        baud_rate,
+        read_termination="\n",
+        write_termination="\n",
+        timeout=None,
+        wait_after_connect=0.0,
+    ) -> None:
+        self.visa_instr = self._setup_device(
+            id=id,
+            baud_rate=baud_rate,
+            read_termination=read_termination,
+            write_termination=write_termination,
+            timeout=timeout,
+            wait_after_connect=wait_after_connect,
+        )
+
+    @staticmethod
+    def _setup_device(
+        id,
+        baud_rate,
+        read_termination="\n",
+        write_termination="\n",
+        timeout=None,
+        wait_after_connect=0.0,
+    ):
+        """Open a visa connection to the device
+
+        Params:
+            wait_after_connect - Time to wait after opening the connection before flushing it [s]
+
+        Raises:
+            RuntimeError: Raised if VISA comms fail
+
+        :rtype: :class:pyvisa.resources.Resource
+        """
+        id_resolved = get_com_port_by_hwid(id)
+
+        if id_resolved.lower() == id.lower():
+            logger.warning(
+                (
+                    "Initiated device from COM port: it would be more "
+                    'robust to use the HWID instead. For "%s", that\'s "%s"'
+                ),
+                id,
+                id_resolved,
+            )
+
+        logger.debug("Found device %s on COM port %s", id, id_resolved)
+
+        # Get a handle to the instrument
+        rm = pyvisa.ResourceManager("@py")
+
+        logger.debug(f"Devices: {rm.list_resources()}")
+
+        # pyvisa-py doesn't have "COM" aliases for ASRL serial ports, so convert
+        regex_match = re.match(r"^com(\d{1,3})$", id_resolved.lower())
+        if regex_match:
+            id_resolved = f"ASRL{regex_match[1]}"
+
+        logger.debug(f"Connecting to : {id_resolved}")
+
+        instr = rm.open_resource(id_resolved)
+
+        logger.debug(f"Connection: {instr}")
+
+        # Configure the connection as required
+
+        logger.debug(
+            "Setting up connection with baud %s, write_term %s and read_term %s",
+            baud_rate,
+            repr(write_termination),
+            repr(read_termination),
+        )
+
+        instr.baud_rate = baud_rate
+        if read_termination:
+            instr.read_termination = read_termination
+        if write_termination:
+            instr.write_termination = write_termination
+        if timeout:
+            instr.timeout = timeout
+        # instr.data_bits = 8
+        # instr.stop_bits = pyvisa.constants.StopBits.one
+        # instr.parity = pyvisa.constants.Parity.none
+        # instr.flow_control = visa.constants.VI_ASRL_FLOW_NONE
+
+        if wait_after_connect:
+            time.sleep(wait_after_connect)
+
+        logger.debug('Device "{}" init complete'.format(id))
+
+        return instr
+
+    def flush(self):
+        logger.debug("Flushing visa interface with device %s", self.visa_instr)
+        self.visa_instr.flush(
+            pyvisa.constants.VI_READ_BUF_DISCARD
+            | pyvisa.constants.VI_WRITE_BUF_DISCARD
+            | pyvisa.constants.VI_IO_IN_BUF_DISCARD
+            | pyvisa.constants.VI_IO_OUT_BUF_DISCARD
+        )
+
+    def write(self, s: str) -> None:
+        self.visa_instr.write(s)
+
+    def query(self, s: str) -> str:
+        return self.visa_instr.query(s)
+
+    def close(self) -> None:
+        self.visa_instr.close()

--- a/generic_scpi_driver/visa_session.py
+++ b/generic_scpi_driver/visa_session.py
@@ -1,10 +1,11 @@
-from .session import Session
 import logging
-
-import pyvisa
 import re
 import time
+
+import pyvisa
 from serial.tools.list_ports import grep as grep_serial_ports
+
+from .session import Session
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "generic-scpi-driver"
-version = "1.4.2"
+version = "1.5"
 description = "A generic template for creating python object-based drivers for SCPI hardware devices which communicate via VISA. Compatible with ARTIQ  installed with [artiq] modifier"
 authors = ["Charles Baynham <charles.baynham@gmail.com>"]
 readme = "README.rst"


### PR DESCRIPTION
Separates the communication logic from the parsing logic so that non-serial devices can be added by defining a new Session interface. 